### PR TITLE
#18438 - Default Slack listener - Invalid code invocation

### DIFF
--- a/listeners/webhooks.js
+++ b/listeners/webhooks.js
@@ -43,7 +43,12 @@ listeners.defaultSlashCommands = {
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
                 sys.logs.info('[slack] Valid slash command received. Triggering package event.');
                 sys.events.triggerEvent("slack:slashCommand", event.data);
-                return app[pkg.slack.utils.getConfiguration("slackLibrary")].slashCommand(event.data);
+                if (pkg.slack.utils.getConfiguration("slashCommandEnabled")) {
+                    //return pkg.slack.utils.getConfiguration("slashCommandScript");
+                    return pkg.slack.config.actionScript({eventData: event.data});
+                } else {
+                    return "Command received!";
+                }
         } else {
             sys.logs.warn('[slack] Invalid verification token for event slash command');
         }
@@ -85,8 +90,9 @@ listeners.defaultOptionLoads = {
         sys.logs.info('[slack] Received slack options load webhook. Processing and triggering a package event.');
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
             sys.logs.info('[slack] Valid option load received. Triggering package event.');
-            sys.events.triggerEvent("slack:optionsLoad", event.data);
-            return app[pkg.slack.utils.getConfiguration("slackLibrary")].optionLoad(event.data);
+            if (pkg.slack.utils.getConfiguration("optionLoadEnabled")) {
+                return pkg.slack.config.optionLoadScript({eventData: event.data});
+            }
         } else {
             sys.logs.warn('[slack] Invalid verification token for event options load');
         }

--- a/listeners/webhooks.js
+++ b/listeners/webhooks.js
@@ -44,7 +44,7 @@ listeners.defaultSlashCommands = {
                 sys.logs.info('[slack] Valid slash command received. Triggering package event.');
                 sys.events.triggerEvent("slack:slashCommand", event.data);
                 if (pkg.slack.utils.getConfiguration("slashCommandsEnabled")) {
-                    return pkg.slack.config.slashCommandsScript({eventData: event.data});
+                    return sys.utils.script.eval(pkg.slack.utils.getConfiguration("slashCommandsScript"), {eventData: event.data});
                 } else {
                     return "Command received!";
                 }
@@ -90,7 +90,7 @@ listeners.defaultOptionLoads = {
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
             sys.logs.info('[slack] Valid option load received. Triggering package event.');
             if (pkg.slack.utils.getConfiguration("optionLoadEnabled")) {
-                return pkg.slack.config.optionLoadScript({eventData: event.data});
+                return sys.utils.script.eval(pkg.slack.utils.getConfiguration("optionLoadScript"), {eventData: event.data});
             } else {
                 return "Option Load request received!";
             }

--- a/listeners/webhooks.js
+++ b/listeners/webhooks.js
@@ -43,7 +43,7 @@ listeners.defaultSlashCommands = {
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
                 sys.logs.info('[slack] Valid slash command received. Triggering package event.');
                 sys.events.triggerEvent("slack:slashCommand", event.data);
-                if (pkg.slack.utils.getConfiguration("slashCommandsEnabled")) {
+                if (pkg.slack.utils.getConfiguration("slashCommandsEnabled") === "true") {
                     return sys.utils.script.eval(pkg.slack.utils.getConfiguration("slashCommandsScript"), {eventData: event.data});
                 } else {
                     return "Command received!";
@@ -89,7 +89,7 @@ listeners.defaultOptionLoads = {
         sys.logs.info('[slack] Received slack options load webhook. Processing and triggering a package event.');
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
             sys.logs.info('[slack] Valid option load received. Triggering package event.');
-            if (pkg.slack.utils.getConfiguration("optionLoadEnabled")) {
+            if (pkg.slack.utils.getConfiguration("optionLoadEnabled") === "true") {
                 return sys.utils.script.eval(pkg.slack.utils.getConfiguration("optionLoadScript"), {eventData: event.data});
             } else {
                 return "Option Load request received!";

--- a/listeners/webhooks.js
+++ b/listeners/webhooks.js
@@ -43,9 +43,8 @@ listeners.defaultSlashCommands = {
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
                 sys.logs.info('[slack] Valid slash command received. Triggering package event.');
                 sys.events.triggerEvent("slack:slashCommand", event.data);
-                if (pkg.slack.utils.getConfiguration("slashCommandEnabled")) {
-                    //return pkg.slack.utils.getConfiguration("slashCommandScript");
-                    return pkg.slack.config.actionScript({eventData: event.data});
+                if (pkg.slack.utils.getConfiguration("slashCommandsEnabled")) {
+                    return pkg.slack.config.slashCommandsScript({eventData: event.data});
                 } else {
                     return "Command received!";
                 }
@@ -92,6 +91,8 @@ listeners.defaultOptionLoads = {
             sys.logs.info('[slack] Valid option load received. Triggering package event.');
             if (pkg.slack.utils.getConfiguration("optionLoadEnabled")) {
                 return pkg.slack.config.optionLoadScript({eventData: event.data});
+            } else {
+                return "Option Load request received!";
             }
         } else {
             sys.logs.warn('[slack] Invalid verification token for event options load');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,26 @@
             "visibility": "config.optionLoadEnabled === true"
         },
         {
+            "name": "slashCommandsEnabled",
+            "label": "Slash Commands Enabled",
+            "description": "Determines whether a Option Load script is needed or not.",
+            "type": "toggle",
+            "multiplicity": "one",
+            "required": true
+        },
+        {
+            "name": "slashCommandsScript",
+            "label": "Slash Commands Script",
+            "description": "The script to be executed when an Option Loads request is performed by Slack.",
+            "type": "script",
+            "multiplicity": "one",
+            "typeOptions": {
+                "parameters": ["eventData"]
+            },
+            "required": "config.optionLoadEnabled === true",
+            "visibility": "config.optionLoadEnabled === true"
+        },
+        {
             "name": "eventsUrl",
             "label": "Events URL",
             "description": "This is the URL you need to set as 'Request URL' in 'Event Subscriptions' page of your app. Keep in mind that the endpoint must be deployed in order to interact with the Slack configuration page. Callback function must be defined on libraries: app.controller.slack.slackEvent",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
             "typeOptions": {
                 "parameters": ["eventData"]
             },
-            "required": "config.optionLoadEnabled === true",
-            "visibility": "config.optionLoadEnabled === true"
+            "required": "config.slashCommandsEnabled === true",
+            "visibility": "config.slashCommandsEnabled === true"
         },
         {
             "name": "eventsUrl",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,24 @@
             "type": "text"
         },
         {
-            "name": "slackLibrary",
-            "label": "Slack Library",
-            "description": "The name of the library where the package will call the corresponding methods for responding to Option Loads and Slash Commands events.",
-            "type": "text",
+            "name": "optionLoadEnabled",
+            "label": "Option Load Enabled",
+            "description": "Determines whether a Option Load script is needed or not.",
+            "type": "toggle",
+            "multiplicity": "one",
             "required": true
+        },
+        {
+            "name": "optionLoadScript",
+            "label": "Option Load Script",
+            "description": "The script to be executed when an Option Loads request is performed by Slack.",
+            "type": "script",
+            "multiplicity": "one",
+            "typeOptions": {
+                "parameters": ["eventData"]
+            },
+            "required": "config.optionLoadEnabled === true",
+            "visibility": "config.optionLoadEnabled === true"
         },
         {
             "name": "eventsUrl",
@@ -83,11 +96,6 @@
             "label": "Interactive Message",
             "name": "interactiveMessage",
             "description": "Happens when a button in a message is pushed."
-        },
-        {
-            "label": "Options Load",
-            "name": "optionsLoad",
-            "description": "Happens when Slack needs to populate a dropdown with options."
         }
     ],
     "metadata": [

--- a/package.json
+++ b/package.json
@@ -27,9 +27,29 @@
             "type": "text"
         },
         {
+            "name": "slashCommandsEnabled",
+            "label": "Slash Commands Enabled",
+            "description": "Determines whether a Slash Command script is needed or not.",
+            "type": "toggle",
+            "multiplicity": "one",
+            "required": true
+        },
+        {
+            "name": "slashCommandsScript",
+            "label": "Slash Commands Script",
+            "description": "The script to be executed when an Slash Command request is performed by Slack.",
+            "type": "script",
+            "multiplicity": "one",
+            "typeOptions": {
+                "parameters": ["eventData"]
+            },
+            "required": "config.slashCommandsEnabled === true",
+            "visibility": "config.slashCommandsEnabled === true"
+        },
+        {
             "name": "optionLoadEnabled",
             "label": "Option Load Enabled",
-            "description": "Determines whether a Option Load script is needed or not.",
+            "description": "Determines whether an Option Load script is needed or not.",
             "type": "toggle",
             "multiplicity": "one",
             "required": true
@@ -45,26 +65,6 @@
             },
             "required": "config.optionLoadEnabled === true",
             "visibility": "config.optionLoadEnabled === true"
-        },
-        {
-            "name": "slashCommandsEnabled",
-            "label": "Slash Commands Enabled",
-            "description": "Determines whether a Option Load script is needed or not.",
-            "type": "toggle",
-            "multiplicity": "one",
-            "required": true
-        },
-        {
-            "name": "slashCommandsScript",
-            "label": "Slash Commands Script",
-            "description": "The script to be executed when an Option Loads request is performed by Slack.",
-            "type": "script",
-            "multiplicity": "one",
-            "typeOptions": {
-                "parameters": ["eventData"]
-            },
-            "required": "config.slashCommandsEnabled === true",
-            "visibility": "config.slashCommandsEnabled === true"
         },
         {
             "name": "eventsUrl",


### PR DESCRIPTION
### **User description**
Pull-request for issue [#18438](https://github.com/slingr-stack/platform/issues/18438) created by @germanm98 

## What it does?

Adds new properties to the package configuration in order to configure scripts for Slack option loads and slash commands requests.

## How to test it?
Create a Slack app in [Slack](api.slack.com) and create a slash command, an interactive message and set a url for those slack features, then set an option load url also. You can check the documentation to know how to do these steps (also review the documentation to check if this steps are understandable in the README).
**NOTE:** there is a bug when you configure scripts with line breaks in the package configuration, you should use the branch **feature/#18438-default-slack-listener-invalid-code-invocation** of the platform to avoid this error.


Remember to use this [checklist](https://docs.google.com/document/d/139rKhIsvpT3yBSB88BBZfy03fD_Sried0bVwIWVaHJk/edit?usp=sharing) for the review.


## Technical notes

There are no technical notes.

## Deployment notes

There are no deployment notes.