### PR TITLE
Minor changes for option loads and slash commands scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ When you use the package, you can indicate which token you need to use.
 
 This flag determines whether a slash commands script is required.
 
-**Name**: `slashCommandsEnabled` **Type**: toggle **Mandatory**: true
+**Name**: `slashCommandsEnabled` **Type**: toggle **Mandatory**: false
 
 ### Slash Commands Script
 
@@ -82,7 +82,7 @@ The script will have access to the event object sent by Slack, allowing you to u
 
 This flag determines whether an option load script is required.
 
-**Name**: `optionLoadEnabled` **Type**: toggle **Mandatory**: true
+**Name**: `optionLoadEnabled` **Type**: toggle **Mandatory**: false
 
 ### Option Load Script
 

--- a/README.md
+++ b/README.md
@@ -151,44 +151,37 @@ In order to give custom responses to Slash Commands and Option Loads requests yo
 ```javascript
 
 //Slash Commands script example
-function slashCommandsScript(eventData) {
-  return {
-    response_type: 'in_channel',
-    text: 'Selecciona una opción:',
-    attachments: [
-      { text: 'Elige una opción',
-        fallback: '¡Tu plataforma no soporta interacciones!',
-        callback_id: 'option_load_1',
-        actions: [ {
-          name: 'option_load',
-          text: 'Cargando opciones...',
-          type: 'select',
-          data_source: 'external',
-          placeholder: {
-            type: 'plain_text',
-            text: 'Cargando...'
-          },
-          action_id: 'load_options'
-        } ]
+return {
+  response_type: 'in_channel',
+  text: 'Selecciona una opción:',
+  attachments: [
+    { text: 'Elige una opción',
+      fallback: '¡Tu plataforma no soporta interacciones!',
+      callback_id: 'option_load_1',
+      actions: [ {
+        name: 'option_load',
+        text: 'Cargando opciones...',
+        type: 'select',
+        data_source: 'external',
+        placeholder: {
+          type: 'plain_text',
+          text: 'Cargando...'
+        },
+        action_id: 'load_options'
       } ]
-  };
-}
-slashCommandsScript(context.eventData); //as this script will be executed in an eval method you need to call the parameter as a property of the global object "context"
+    } ]
+};
 
 //Option Loads script exampl
-function optionLoadScript(eventData){
-  return {
-    options: [{
-      text: {
-        type: 'plain_text',
-        text: 'Opción 1'
-      },
-      value: 'option1'
-    }]
-  };
-}
-optionLoadScript(context.eventData); //as this script will be executed in an eval method you need to call the parameter as a property of the global object "context"
-
+return {
+  options: [{
+    text: {
+      text: 'Opción 1',
+      type: 'plain_text'
+    },
+    value: 'option1'
+  }]
+};
 ```
 
 Please take a look at the documentation of the [HTTP service](https://github.com/slingr-stack/http-service)

--- a/listeners/webhooks.js
+++ b/listeners/webhooks.js
@@ -39,7 +39,7 @@ listeners.defaultSlashCommands = {
         }
     },
     callback: function(event) {
-        sys.logs.info('[slack] Received slack slash command webhook. Processing and triggering a package event.');
+        sys.logs.info('[slack] Received slack slash command webhook. Processing event.');
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
                 sys.logs.info('[slack] Valid slash command received.');
                 if (pkg.slack.utils.getConfiguration("slashCommandsEnabled") === "true") {

--- a/listeners/webhooks.js
+++ b/listeners/webhooks.js
@@ -41,11 +41,12 @@ listeners.defaultSlashCommands = {
     callback: function(event) {
         sys.logs.info('[slack] Received slack slash command webhook. Processing and triggering a package event.');
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
-                sys.logs.info('[slack] Valid slash command received. Triggering package event.');
-                sys.events.triggerEvent("slack:slashCommand", event.data);
+                sys.logs.info('[slack] Valid slash command received.');
                 if (pkg.slack.utils.getConfiguration("slashCommandsEnabled") === "true") {
-                    return sys.utils.script.eval(pkg.slack.utils.getConfiguration("slashCommandsScript"), {eventData: event.data});
+                    let customCode = pkg.slack.utils.createWrapper("slashCommandsScript", pkg.slack.utils.getConfiguration("slashCommandsScript"));
+                    return sys.utils.script.eval(customCode, {eventData: event.data});
                 } else {
+                    sys.events.triggerEvent("slack:slashCommand", event.data);
                     return "Command received!";
                 }
         } else {
@@ -67,7 +68,7 @@ listeners.defaultInteractiveMessages = {
     callback: function(event) {
         sys.logs.info('[slack] Received slack interactive webhook. Processing and triggering a package event.');
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
-            sys.logs.info('[slack] Valid interactive message received. Triggering package event.');
+            sys.logs.info('[slack] Valid interactive message received.');
             sys.events.triggerEvent("slack:interactiveMessage", event.data);
         } else {
             sys.logs.warn('[slack] Invalid verification token for interactive event');
@@ -88,9 +89,10 @@ listeners.defaultOptionLoads = {
     callback: function(event) {
         sys.logs.info('[slack] Received slack options load webhook. Processing and triggering a package event.');
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
-            sys.logs.info('[slack] Valid option load received. Triggering package event.');
+            sys.logs.info('[slack] Valid option load received.');
             if (pkg.slack.utils.getConfiguration("optionLoadEnabled") === "true") {
-                return sys.utils.script.eval(pkg.slack.utils.getConfiguration("optionLoadScript"), {eventData: event.data});
+                let customCode = pkg.slack.utils.createWrapper("optionLoadScript", pkg.slack.utils.getConfiguration("optionLoadScript"));
+                return sys.utils.script.eval(customCode, {eventData: event.data});
             } else {
                 return "Option Load request received!";
             }

--- a/listeners/webhooks.js
+++ b/listeners/webhooks.js
@@ -87,7 +87,7 @@ listeners.defaultOptionLoads = {
         }
     },
     callback: function(event) {
-        sys.logs.info('[slack] Received slack options load webhook. Processing and triggering a package event.');
+        sys.logs.info('[slack] Received slack options load webhook. Processing event.');
         if (pkg.slack.utils.verifyToken(event.data.body.token) || pkg.slack.utils.verifyToken(event.data.body.payload.token)) {
             sys.logs.info('[slack] Valid option load received.');
             if (pkg.slack.utils.getConfiguration("optionLoadEnabled") === "true") {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
             "description": "Determines whether a Slash Command script is needed or not.",
             "type": "toggle",
             "multiplicity": "one",
-            "required": true
+            "required": false
         },
         {
             "name": "slashCommandsScript",
@@ -52,7 +52,7 @@
             "description": "Determines whether an Option Load script is needed or not.",
             "type": "toggle",
             "multiplicity": "one",
-            "required": true
+            "required": false
         },
         {
             "name": "optionLoadScript",

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -47,12 +47,8 @@ exports.createWrapper = function (wrapperName, code) {
  */
 function escapeForEval(code) {
     return code
-        .replace(/\\/g, '\\\\')
-        .replace(/`/g, '\\`')
-        .replace(/\/\*/g, '/\\*')
-        .replace(/\*\//g, '*\\/')
-        .replace(/\/\/(.+)?$/gm, '// $1')
-        .replace(/\r/g, '')
-        .replace(/\t/g, '  ');
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/.*$/gm, '')
+        .replace(/`/g, '\\`');
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -51,6 +51,7 @@ function escapeForEval(code) {
         .replace(/`/g, '\\`')
         .replace(/\/\*/g, '/\\*')
         .replace(/\*\//g, '*\\/')
+        .replace(/\/\/(.+)?$/gm, '// $1')
         .replace(/\r/g, '')
         .replace(/\t/g, '  ');
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -34,7 +34,24 @@ exports.verifyToken = function (token) {
  */
 exports.createWrapper = function (wrapperName, code) {
     return `function ${wrapperName}(eventData) {
-        ${code}
+        ${escapeForEval(code)}
     }
     ${wrapperName}(context.eventData);`;
 };
+
+/**
+ * Escapes potentially problematic characters for safe use in dynamically evaluated code.
+ *
+ * @param {string} code - The raw source code to sanitize before injecting into an eval wrapper.
+ * @returns {string} - A sanitized, safe-to-eval string version of the input code.
+ */
+function escapeForEval(code) {
+    return code
+        .replace(/\\/g, '\\\\')
+        .replace(/`/g, '\\`')
+        .replace(/\/\*/g, '/\\*')
+        .replace(/\*\//g, '*\\/')
+        .replace(/\r/g, '')
+        .replace(/\t/g, '  ');
+}
+

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -24,3 +24,17 @@ exports.getConfiguration = function (property) {
 exports.verifyToken = function (token) {
     return token === config.get("verificationToken");
 };
+
+/**
+ * Creates a wrapper function to execute custom code through eval method.
+ *
+ * @param {string} wrapperName           - The name of the wrapper function
+ * @param {string} code                 - The code to be executed inside the wrapper.
+ * @return {string}                    - The string wrapper function.
+ */
+exports.createWrapper = function (wrapperName, code) {
+    return `function ${wrapperName}(eventData) {
+        ${code}
+    }
+    ${wrapperName}(context.eventData);`;
+};


### PR DESCRIPTION
### **User description**
Pull-request created by @germanm98 

## What it does?
Added safe script evaluation and wrapper for option loads and slash commands to execute scripts correctly in Rhino.

## How to test it?
Create a Slack app in [Slack](api.slack.com) and create a slash command, an interactive message and set a url for those slack features, then set an option load url also. You can check the documentation to know how to do these steps (also review the documentation to check if this steps are understandable in the README).


Remember to use this [checklist](https://docs.google.com/document/d/139rKhIsvpT3yBSB88BBZfy03fD_Sried0bVwIWVaHJk/edit?usp=sharing) for the review.


## Technical notes

There are no technical notes.

## Deployment notes

There are no deployment notes.